### PR TITLE
aiohttp: Add cookies support

### DIFF
--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -180,9 +180,8 @@ def test_params_same_url_distinct_params(tmpdir, scheme):
 
     other_params = {"other": "params"}
     with vcr.use_cassette(str(tmpdir.join("get.yaml"))) as cassette:
-        response, cassette_response_text = get(url, output="text", params=other_params)
-        assert "No match for the request" in cassette_response_text
-        assert response.status == 599
+        with pytest.raises(vcr.errors.CannotOverwriteExistingCassetteException):
+            get(url, output="text", params=other_params)
 
 
 def test_params_on_url(tmpdir, scheme):

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -322,18 +322,14 @@ def test_cookies(scheme, tmpdir):
         with vcr.use_cassette(tmp) as cassette:
             async with aiohttp.ClientSession() as session:
                 cookies_resp = await session.get(cookies_url)
-                home_resp = await session.get(
-                    home_url, cookies=req_cookies, headers=req_headers
-                )
+                home_resp = await session.get(home_url, cookies=req_cookies, headers=req_headers)
         assert_responses(cookies_resp, home_resp)
 
         # -------------------------- Play --------------------------- #
         with vcr.use_cassette(tmp, record_mode="none") as cassette:
             async with aiohttp.ClientSession() as session:
                 cookies_resp = await session.get(cookies_url)
-                home_resp = await session.get(
-                    home_url, cookies=req_cookies, headers=req_headers
-                )
+                home_resp = await session.get(home_url, cookies=req_cookies, headers=req_headers)
         assert_responses(cookies_resp, home_resp)
 
     def assert_responses(cookies_resp, home_resp):

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import urllib.parse
 
 import pytest
 
@@ -302,3 +303,23 @@ def test_double_requests(tmpdir):
 
         # Now that we made both requests, we should have played both.
         assert cassette.play_count == 2
+
+
+def test_cookies(scheme, tmpdir):
+    url = scheme + (
+        '://httpbin.org/response-headers?'
+        'set-cookie=' + urllib.parse.quote('cookie_1=val_1; Path=/') + '&'
+        'Set-Cookie=' + urllib.parse.quote('Cookie_2=Val_2; Path=/')
+    )
+    with vcr.use_cassette(str(tmpdir.join("cookies.yaml"))) as cassette:
+        response, _ = get(url, output='json')
+
+    assert response.cookies.get('cookie_1').value == 'val_1'
+    assert response.cookies.get('Cookie_2').value == 'Val_2'
+
+    with vcr.use_cassette(str(tmpdir.join("cookies.yaml"))) as cassette:
+        response, _ = get(url, output='json')
+        assert cassette.play_count == 1
+
+    assert response.cookies.get('cookie_1').value == 'val_1'
+    assert response.cookies.get('Cookie_2').value == 'Val_2'

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import logging
 import urllib.parse
@@ -306,20 +307,42 @@ def test_double_requests(tmpdir):
 
 
 def test_cookies(scheme, tmpdir):
-    url = scheme + (
-        "://httpbin.org/response-headers?"
-        "set-cookie=" + urllib.parse.quote("cookie_1=val_1; Path=/") + "&"
-        "Set-Cookie=" + urllib.parse.quote("Cookie_2=Val_2; Path=/")
-    )
-    with vcr.use_cassette(str(tmpdir.join("cookies.yaml"))) as cassette:
-        response, _ = get(url, output="json")
+    async def run(scheme, tmpdir):
+        cookies_url = scheme + (
+            "://httpbin.org/response-headers?"
+            "set-cookie=" + urllib.parse.quote("cookie_1=val_1; Path=/") + "&"
+            "Set-Cookie=" + urllib.parse.quote("Cookie_2=Val_2; Path=/")
+        )
+        home_url = scheme + "://httpbin.org/"
+        tmp = str(tmpdir.join("cookies.yaml"))
+        req_cookies = {"Cookie_3": "Val_3"}
+        req_headers = {"Cookie": "Cookie_4=Val_4"}
 
-    assert response.cookies.get("cookie_1").value == "val_1"
-    assert response.cookies.get("Cookie_2").value == "Val_2"
+        # ------------------------- Record -------------------------- #
+        with vcr.use_cassette(tmp) as cassette:
+            async with aiohttp.ClientSession() as session:
+                cookies_resp = await session.get(cookies_url)
+                home_resp = await session.get(
+                    home_url, cookies=req_cookies, headers=req_headers
+                )
+        assert_responses(cookies_resp, home_resp)
 
-    with vcr.use_cassette(str(tmpdir.join("cookies.yaml"))) as cassette:
-        response, _ = get(url, output="json")
-        assert cassette.play_count == 1
+        # -------------------------- Play --------------------------- #
+        with vcr.use_cassette(tmp, record_mode="none") as cassette:
+            async with aiohttp.ClientSession() as session:
+                cookies_resp = await session.get(cookies_url)
+                home_resp = await session.get(
+                    home_url, cookies=req_cookies, headers=req_headers
+                )
+        assert_responses(cookies_resp, home_resp)
 
-    assert response.cookies.get("cookie_1").value == "val_1"
-    assert response.cookies.get("Cookie_2").value == "Val_2"
+    def assert_responses(cookies_resp, home_resp):
+        assert cookies_resp.cookies.get("cookie_1").value == "val_1"
+        assert cookies_resp.cookies.get("Cookie_2").value == "Val_2"
+        request_cookies = home_resp.request_info.headers["cookie"]
+        assert "cookie_1=val_1" in request_cookies
+        assert "Cookie_2=Val_2" in request_cookies
+        assert "Cookie_3=Val_3" in request_cookies
+        assert "Cookie_4=Val_4" in request_cookies
+
+    asyncio.run(run(scheme, tmpdir))

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -307,19 +307,19 @@ def test_double_requests(tmpdir):
 
 def test_cookies(scheme, tmpdir):
     url = scheme + (
-        '://httpbin.org/response-headers?'
-        'set-cookie=' + urllib.parse.quote('cookie_1=val_1; Path=/') + '&'
-        'Set-Cookie=' + urllib.parse.quote('Cookie_2=Val_2; Path=/')
+        "://httpbin.org/response-headers?"
+        "set-cookie=" + urllib.parse.quote("cookie_1=val_1; Path=/") + "&"
+        "Set-Cookie=" + urllib.parse.quote("Cookie_2=Val_2; Path=/")
     )
     with vcr.use_cassette(str(tmpdir.join("cookies.yaml"))) as cassette:
-        response, _ = get(url, output='json')
+        response, _ = get(url, output="json")
 
-    assert response.cookies.get('cookie_1').value == 'val_1'
-    assert response.cookies.get('Cookie_2').value == 'Val_2'
+    assert response.cookies.get("cookie_1").value == "val_1"
+    assert response.cookies.get("Cookie_2").value == "Val_2"
 
     with vcr.use_cassette(str(tmpdir.join("cookies.yaml"))) as cassette:
-        response, _ = get(url, output='json')
+        response, _ = get(url, output="json")
         assert cassette.play_count == 1
 
-    assert response.cookies.get('cookie_1').value == 'val_1'
-    assert response.cookies.get('Cookie_2').value == 'Val_2'
+    assert response.cookies.get("cookie_1").value == "val_1"
+    assert response.cookies.get("Cookie_2").value == "Val_2"

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -1,4 +1,3 @@
-import asyncio
 import contextlib
 import logging
 import urllib.parse
@@ -307,7 +306,7 @@ def test_double_requests(tmpdir):
 
 
 def test_cookies(scheme, tmpdir):
-    async def run(scheme, tmpdir):
+    async def run(loop):
         cookies_url = scheme + (
             "://httpbin.org/response-headers?"
             "set-cookie=" + urllib.parse.quote("cookie_1=val_1; Path=/") + "&"
@@ -320,16 +319,18 @@ def test_cookies(scheme, tmpdir):
 
         # ------------------------- Record -------------------------- #
         with vcr.use_cassette(tmp) as cassette:
-            async with aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession(loop=loop) as session:
                 cookies_resp = await session.get(cookies_url)
                 home_resp = await session.get(home_url, cookies=req_cookies, headers=req_headers)
+                assert cassette.play_count == 0
         assert_responses(cookies_resp, home_resp)
 
         # -------------------------- Play --------------------------- #
         with vcr.use_cassette(tmp, record_mode="none") as cassette:
-            async with aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession(loop=loop) as session:
                 cookies_resp = await session.get(cookies_url)
                 home_resp = await session.get(home_url, cookies=req_cookies, headers=req_headers)
+                assert cassette.play_count == 2
         assert_responses(cookies_resp, home_resp)
 
     def assert_responses(cookies_resp, home_resp):
@@ -341,4 +342,4 @@ def test_cookies(scheme, tmpdir):
         assert "Cookie_3=Val_3" in request_cookies
         assert "Cookie_4=Val_4" in request_cookies
 
-    asyncio.run(run(scheme, tmpdir))
+    run_in_loop(run)

--- a/vcr/stubs/aiohttp_stubs.py
+++ b/vcr/stubs/aiohttp_stubs.py
@@ -249,9 +249,7 @@ def vcr_request(cassette, real_request):
             return response
 
         if cassette.write_protected and cassette.filter_request(vcr_request):
-            raise CannotOverwriteExistingCassetteException(
-                cassette=cassette, failed_request=vcr_request
-            )
+            raise CannotOverwriteExistingCassetteException(cassette=cassette, failed_request=vcr_request)
 
         log.info("%s not in cassette, sending to real server", vcr_request)
 

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -235,9 +235,7 @@ def vcr_request(cassette, real_request):
             request_url = URL(url).with_query(params)
 
         c_header = headers.pop(hdrs.COOKIE, None)
-        cookie_header = _build_cookie_header(
-            self, cookies, c_header, request_url
-        )
+        cookie_header = _build_cookie_header(self, cookies, c_header, request_url)
         if cookie_header:
             headers[hdrs.COOKIE] = cookie_header
 

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -5,8 +5,9 @@ import logging
 import json
 
 from aiohttp import ClientConnectionError, ClientResponse, RequestInfo, streams
-from aiohttp import hdrs
-from http.cookies import CookieError
+from aiohttp import hdrs, CookieJar
+from http.cookies import CookieError, Morsel, SimpleCookie
+from aiohttp.helpers import strip_auth_from_url
 from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL
 
@@ -187,6 +188,33 @@ async def record_responses(cassette, vcr_request, response):
     await record_response(cassette, vcr_request, response)
 
 
+def _build_cookie_header(session, cookies, cookie_header, url):
+    url, _ = strip_auth_from_url(url)
+    all_cookies = session._cookie_jar.filter_cookies(url)
+    if cookies is not None:
+        tmp_cookie_jar = CookieJar()
+        tmp_cookie_jar.update_cookies(cookies)
+        req_cookies = tmp_cookie_jar.filter_cookies(request_url)
+        if req_cookies:
+            all_cookies.load(req_cookies)
+
+    if not all_cookies:
+        return None
+
+    c = SimpleCookie()
+    if cookie_header:
+        c.load(cookie_header)
+    for name, value in all_cookies:
+        if isinstance(value, Morsel):
+            mrsl_val = value.get(value.key, Morsel())
+            mrsl_val.set(value.key, value.value, value.coded_value)
+            c[name] = mrsl_val
+        else:
+            c[name] = value
+
+    return c.output(header="", sep=";").strip()
+
+
 def vcr_request(cassette, real_request):
     @functools.wraps(real_request)
     async def new_request(self, method, url, **kwargs):
@@ -195,6 +223,7 @@ def vcr_request(cassette, real_request):
         headers = self._prepare_headers(headers)
         data = kwargs.get("data", kwargs.get("json"))
         params = kwargs.get("params")
+        cookies = kwargs.get("cookies")
 
         if auth is not None:
             headers["AUTHORIZATION"] = auth.encode()
@@ -204,6 +233,13 @@ def vcr_request(cassette, real_request):
             for k, v in params.items():
                 params[k] = str(v)
             request_url = URL(url).with_query(params)
+
+        c_header = self.headers.pop(hdrs.COOKIE, None)
+        cookies_header = _build_cookie_header(
+            self, cookies, c_header, request_url
+        )
+        if cookies_header:
+            self.headers[hdrs.COOKIE] = cookies_header
 
         vcr_request = Request(method, str(request_url), data, headers)
 

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -208,7 +208,11 @@ def vcr_request(cassette, real_request):
         vcr_request = Request(method, str(request_url), data, headers)
 
         if cassette.can_play_response_for(vcr_request):
-            return play_responses(cassette, vcr_request)
+            response = play_responses(cassette, vcr_request)
+            for resp in response.history:
+                self._cookie_jar.update_cookies(resp.cookies, resp.url)
+            self._cookie_jar.update_cookies(response.cookies, response.url)
+            return response
 
         if cassette.write_protected and cassette.filter_request(vcr_request):
             response = MockClientResponse(method, URL(url))

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -239,7 +239,7 @@ def vcr_request(cassette, real_request):
         if cookie_header:
             headers[hdrs.COOKIE] = cookie_header
 
-        vcr_request = Request(method, str(request_url), data, headers)
+        vcr_request = Request(method, str(request_url), data, _serialize_headers(headers))
 
         if cassette.can_play_response_for(vcr_request):
             response = play_responses(cassette, vcr_request)

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -76,7 +76,7 @@ def build_response(vcr_request, vcr_response, history):
         try:
             response.cookies.load(hdr)
         except CookieError as exc:
-            log.warning('Can not load response cookies: %s', exc)
+            log.warning("Can not load response cookies: %s", exc)
 
     response.close()
     return response

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -194,17 +194,17 @@ def _build_cookie_header(session, cookies, cookie_header, url):
     if cookies is not None:
         tmp_cookie_jar = CookieJar()
         tmp_cookie_jar.update_cookies(cookies)
-        req_cookies = tmp_cookie_jar.filter_cookies(request_url)
+        req_cookies = tmp_cookie_jar.filter_cookies(url)
         if req_cookies:
             all_cookies.load(req_cookies)
 
-    if not all_cookies:
+    if not all_cookies and not cookie_header:
         return None
 
     c = SimpleCookie()
     if cookie_header:
         c.load(cookie_header)
-    for name, value in all_cookies:
+    for name, value in all_cookies.items():
         if isinstance(value, Morsel):
             mrsl_val = value.get(value.key, Morsel())
             mrsl_val.set(value.key, value.value, value.coded_value)
@@ -234,19 +234,17 @@ def vcr_request(cassette, real_request):
                 params[k] = str(v)
             request_url = URL(url).with_query(params)
 
-        c_header = self.headers.pop(hdrs.COOKIE, None)
-        cookies_header = _build_cookie_header(
+        c_header = headers.pop(hdrs.COOKIE, None)
+        cookie_header = _build_cookie_header(
             self, cookies, c_header, request_url
         )
-        if cookies_header:
-            self.headers[hdrs.COOKIE] = cookies_header
+        if cookie_header:
+            headers[hdrs.COOKIE] = cookie_header
 
         vcr_request = Request(method, str(request_url), data, headers)
 
         if cassette.can_play_response_for(vcr_request):
             response = play_responses(cassette, vcr_request)
-            for resp in response.history:
-                self._cookie_jar.update_cookies(resp.cookies, resp.url)
             self._cookie_jar.update_cookies(response.cookies, response.url)
             return response
 


### PR DESCRIPTION
## What
Read/store cookies and enable multiple headers with same key (e.g. `Set-Cookie`).

## Why
To be able to match and test cookies.